### PR TITLE
Lisbon Macro Workshop

### DIFF
--- a/LisbonMacro/index.html
+++ b/LisbonMacro/index.html
@@ -21,7 +21,7 @@
     {"headline":"Lisbon Macro Workshop","url":"https://nicjkoz.com/LisbonMacro/","@type":"WebSite","publisher":{"@type":"Organization","logo":{"@type":"ImageObject","url":"https://nicjkoz.com/Profile_NJK.jpg"}},"name":"Lisbon macro Workshop","@context":"https://schema.org"}</script>
     <!-- End Jekyll SEO tag -->
 
-    <link rel="stylesheet" href="../css/custom_style.css">  
+    <link rel="stylesheet" href="../css/custom_style_LisbonMacro.css">  
     <link rel="shortcut icon" href="../favicon.png" type="image/x-icon">  
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,600,700,900" type="text/css" rel="stylesheet">
  
@@ -32,7 +32,7 @@
 <div class="wrapper">
 
 <!-- Left column of page -->      
-<header>
+<!-- <header>
     <h1><a href="https://www.nicjkoz.com/">Nicholas Kozeniauskas</a></h1>
     
     <div style="display:inline;float:center">
@@ -47,7 +47,7 @@
         <br> <a href="https://nicjkoz.github.io/LisbonMacro/">Lisbon Macro Workshop</a>
 	</p>
             
-</header>
+</header> -->
 
 
 <section>
@@ -55,12 +55,20 @@
 
     <h1 id="publications">Lisbon Macro Workshop</h1>
 
+    <h4 id="publications">September 1&ndash;2, 2023</h1>
+
     <p>
-    <br />The second edition of the Lisbon Macro Workshop will be held on September 1&ndash;2, 2023, at Católica Lisbon School of Business & Economics. 
+    <br />The second edition of the Lisbon Macro Workshop will be held on September 1&ndash;2, 2023, at Católica Lisbon School of Business & Economics. We are currently taking submissions and are interested in papers in any area of macro. The final program will reflect the interests of the participants and organizers.
     <br />
-    <br />The call for papers will be released shortly. If you would like to sign up to receive it, please send us an email at <a href="mailto:lisbonmacro@gmail.com">lisbonmacro@gmail.com</a>.
+    <br /> The program will include presentations with discussants, as well as sessions with shorter presentations in which discussants present their own work.
     <br />
-    <br /> The program from last year's workshop is available <a href="https://nicjkoz.github.io/files/LisbonMacro_Program_2022.pdf">here</a>.
+    <br /> Participants will need to cover their own travel and accommodation, and there will be a registration fee of approximately €90 to cover meals and catering during the conference.
+    <br />
+    <br /> <b>Submissions:</b> submissions can be made with <a href="https://www.cognitoforms.com/LisbonMacro/_2023LisbonMacroWorkshopSubmission">this form</a> until April 30.    
+    <br />
+    <br />For anyone who is interested, the program from last year's workshop is available <a href="https://nicjkoz.github.io/files/LisbonMacro_Program_2022.pdf">here</a>. 
+    <br />
+    <br />If you have any questions, please email us at <a href="mailto:lisbonmacro@gmail.com">lisbonmacro@gmail.com</a>.
     <br />
     <br /> We look forward to seeing you in Lisbon!
     <br />
@@ -70,7 +78,7 @@
     <br /> Chiara Lacava
     <br /> Laszlo Tetenyi
     </p> 
-        
+
 </section>
       
 </div>

--- a/LisbonMacro/index.html
+++ b/LisbonMacro/index.html
@@ -60,15 +60,15 @@
     <p>
     <br />The second edition of the Lisbon Macro Workshop will be held on September 1&ndash;2, 2023, at Católica Lisbon School of Business & Economics. We are currently taking submissions and are interested in papers in any area of macro. The final program will reflect the interests of the participants and organizers.
     <br />
-    <br /> The program will include presentations with discussants, as well as sessions with shorter presentations in which discussants present their own work.
+    <br /> The workshop will include presentations with discussants, as well as sessions with shorter presentations in which discussants present their own work.
     <br />
     <br /> Participants will need to cover their own travel and accommodation, and there will be a registration fee of approximately €90 to cover meals and catering during the conference.
     <br />
-    <br /> <b>Submissions:</b> submissions can be made with <a href="https://www.cognitoforms.com/LisbonMacro/_2023LisbonMacroWorkshopSubmission">this form</a> until April 30.    
+    <br /> <b>Submissions:</b> can be made with <a href="https://www.cognitoforms.com/LisbonMacro/_2023LisbonMacroWorkshopSubmission">this form</a> until April 30.    
     <br />
-    <br />For anyone who is interested, the program from last year's workshop is available <a href="https://nicjkoz.github.io/files/LisbonMacro_Program_2022.pdf">here</a>. 
+    <br />If you are interested, the program from last year's workshop is available <a href="https://nicjkoz.github.io/files/LisbonMacro_Program_2022.pdf">here</a>. 
     <br />
-    <br />If you have any questions, please email us at <a href="mailto:lisbonmacro@gmail.com">lisbonmacro@gmail.com</a>.
+    <br />Any questions, please email us at <a href="mailto:lisbonmacro@gmail.com">lisbonmacro@gmail.com</a>.
     <br />
     <br /> We look forward to seeing you in Lisbon!
     <br />

--- a/css/custom_style_LisbonMacro.css
+++ b/css/custom_style_LisbonMacro.css
@@ -1,0 +1,165 @@
+body {
+ background-color:#fff;
+ padding:50px;
+ font-family: 'Source Sans Pro', Arial, sans-serif;
+ font-size: 19px;
+ line-height: 1.5;
+ color:#424242;
+ font-weight:400
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+ color:rgba(87,6,140,1)
+}
+h1,
+h3,
+h4,
+h5,
+h6 {
+ margin:0 0 20px
+}
+h2 {
+ margin:35px 0 20px	 
+}
+p {
+ margin:0 0 20px
+}
+h1,
+h2,
+h3 {
+ line-height:1.1
+}
+h1 {
+ font-family: 'Source Sans Pro', Arial, Verdana, sans-serif;
+ font-size:32px
+}
+h2 {
+ color:#393939
+}
+h3,
+h4,
+h5,
+h6 {
+ color:#494949
+}
+.subtext {
+ font-weight: normal;
+}
+p {
+ text-align: justify;
+ text-justify: inter-word
+}
+a {
+ color:rgba(87,6,140,1); 
+ text-decoration:none
+}
+a:hover {
+text-decoration: underline;
+}
+.wrapper {
+ width:650px;
+ margin:0 auto
+}
+img {
+ max-width:100%
+}
+/*header {
+ width:270px;
+ float:left;
+ position:fixed;
+ -webkit-font-smoothing:subpixel-antialiased
+}*/
+strong {
+ color:#222;
+ font-weight:700
+}
+section {
+ width:650px;
+ float:none;
+ padding-bottom:50px
+}
+small {
+ font-size:11px
+}
+hr {
+ border:0;
+ background:#e5e5e5;
+ height:1px;
+ margin:0 0 20px
+}
+footer {
+ width:270px;
+ float:left;
+ position:fixed;
+ bottom:50px;
+ -webkit-font-smoothing:subpixel-antialiased
+}
+@media print, screen and (max-width: 960px) {
+ div.wrapper {
+  width:auto;
+  margin:0
+ }
+ header,
+ section,
+ footer {
+  float:none;
+  position:static;
+  width:auto
+ }
+ header {
+  padding-right:320px
+ }
+ section {
+  border:1px solid #e5e5e5;
+  border-width:1px 0;
+  padding:20px 0;
+  margin:0 0 20px
+ }
+ header a small {
+  display:inline
+ }
+ header ul {
+  position:absolute;
+  right:50px;
+  top:52px
+ }
+}
+@media print, screen and (max-width: 720px) {
+ body {
+  word-wrap:break-word
+ }
+ header {
+  padding:0
+ }
+ header ul,
+ header p.view {
+  position:static
+ }
+ pre,
+ code {
+  word-wrap:normal
+ }
+}
+@media print, screen and (max-width: 480px) {
+ body {
+  padding:15px
+ }
+ header ul {
+  width:99%
+ }
+ header li,
+ header ul li+li+li {
+  width:33%
+ }
+}
+@media print {
+ body {
+  padding:0.4in;
+  font-size:12pt;
+  color:#444
+ }
+}

--- a/css/custom_style_LisbonMacro.css
+++ b/css/custom_style_LisbonMacro.css
@@ -114,8 +114,8 @@ footer {
   padding-right:320px
  }
  section {
-  border:1px solid #e5e5e5;
-  border-width:1px 0;
+/*  border:1px solid #e5e5e5;
+  border-width:1px 0;*/
   padding:20px 0;
   margin:0 0 20px
  }


### PR DESCRIPTION
Change format of Lisbon Macro Workshop page to be only for the conference. Create a new CSS file for this page.